### PR TITLE
fix: default country code and language code if missing

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -93,8 +93,10 @@ export class ExampleHomebridgePlatform implements DynamicPlatformPlugin {
 
   async initializeThinqConfig() {
     const partialThinqConfig: PartialThinqConfig = {
-      countryCode: this.config.country_code,
-      languageCode: this.config.language_code,
+      // If a user installs via the homebridge UI, these values
+      // may not be guaranteed
+      countryCode: this.config.country_code || 'US',
+      languageCode: this.config.language_code || 'en-US',
     }
     const gatewayUri = await ThinqApi.getGatewayUri(partialThinqConfig)
     const thinqConfig: ThinqConfig = {


### PR DESCRIPTION
Provide a default country code and language code if they are missing from the provided config. Otherwise, this may fail silently during first boot up if installed through the homebridge UI.

Fair warning, I have yet to test this because I just got my stuff working and haven't quite given it a spin yet. 